### PR TITLE
Added Get-OTPRemainingSeconds function

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,10 @@ Source: https://gist.github.com/jonfriesen/234c7471c3e3199f97d5
 # With all parameters specified, not using alias
 > Get-Otp -SECRET 'secretkeystring' -WINDOW 22 -LENGTH 5
 18017
-```
+
 # Get remaining seconds in current TOTP window, default 30 second window
 > Get-OTPRemainingSeconds
 12
 > Get-OTPRemainingSeconds -WINDOW 20
 5
+```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # TOTPPowerShellModule
 Module for TOTP Client for PowerShell
 
-I created a module for easier user. I did not create the OTP code.
+I created a module for easier use. I did not create the OTP code.
 
 Source: https://gist.github.com/jonfriesen/234c7471c3e3199f97d5
 
@@ -21,3 +21,8 @@ Source: https://gist.github.com/jonfriesen/234c7471c3e3199f97d5
 > Get-Otp -SECRET 'secretkeystring' -WINDOW 22 -LENGTH 5
 18017
 ```
+# Get remaining seconds in current TOTP window, default 30 second window
+> Get-OTPRemainingSeconds
+12
+> Get-OTPRemainingSeconds -WINDOW 20
+5

--- a/TOTP/totp.ps1
+++ b/TOTP/totp.ps1
@@ -39,16 +39,15 @@ function Get-Otp(){
 }
 
 # Get-OTPRemainingSeconds returns how many seconds are left in the current TOTP window. In a script that needs to wait until the next code is generated, use like $RetryDelayInSeconds = Get-OTPRemainingSeconds; Start-Sleep -Seconds $RetryDelayInSeconds
-function Get-OTPRemainingSeconds () {
-    $INTERVAL = 30
+function Get-OTPRemainingSeconds ([int32]$WINDOW = 30) {
     $EPOCH = Get-Date -Year 1970 -Month 1 -Day 1 -Hour 0 -Minute 0 -Second 0
 
     $span = New-TimeSpan -Start $EPOCH -End (Get-Date).ToUniversalTime()
     $seconds = [math]::floor($span.TotalSeconds)
-    $counter = [math]::floor($seconds / $INTERVAL)
-    $counter = [Convert]::ToInt32($seconds / $INTERVAL)
+    $counter = [math]::floor($seconds / $WINDOW)
+    $counter = [Convert]::ToInt32($seconds / $WINDOW)
 
-    $nextTimeStep = ($counter + 1)*$INTERVAL
+    $nextTimeStep = ($counter + 1)*$WINDOW
     $difference = $nextTimeStep - $seconds
 
     return $difference

--- a/TOTP/totp.ps1
+++ b/TOTP/totp.ps1
@@ -38,6 +38,22 @@ function Get-Otp(){
     return $otp
 }
 
+# Get-OTPRemainingSeconds returns how many seconds are left in the current TOTP window. In a script that needs to wait until the next code is generated, use like $RetryDelayInSeconds = Get-OTPRemainingSeconds; Start-Sleep -Seconds $RetryDelayInSeconds
+function Get-OTPRemainingSeconds () {
+    $INTERVAL = 30
+    $EPOCH = Get-Date -Year 1970 -Month 1 -Day 1 -Hour 0 -Minute 0 -Second 0
+
+    $span = New-TimeSpan -Start $EPOCH -End (Get-Date).ToUniversalTime()
+    $seconds = [math]::floor($span.TotalSeconds)
+    $counter = [math]::floor($seconds / $INTERVAL)
+    $counter = [Convert]::ToInt32($seconds / $INTERVAL)
+
+    $nextTimeStep = ($counter + 1)*$INTERVAL
+    $difference = $nextTimeStep - $seconds
+
+    return $difference
+}
+
 function Get-TimeByteArray($WINDOW) {
     $span = (New-TimeSpan -Start (Get-Date -Year 1970 -Month 1 -Day 1 -Hour 0 -Minute 0 -Second 0) -End (Get-Date).ToUniversalTime()).TotalSeconds
     $unixTime = [Convert]::ToInt64([Math]::Floor($span/$WINDOW))

--- a/TOTP/totp.psd1
+++ b/TOTP/totp.psd1
@@ -12,7 +12,7 @@
 # RootModule = ''
 
 # Version number of this module.
-ModuleVersion = '1.0'
+ModuleVersion = '1.1'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()
@@ -69,7 +69,7 @@ Description = 'TOTP Client for PowerShell '
 NestedModules = 'totp.ps1'
 
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
-FunctionsToExport = 'Get-Otp'
+FunctionsToExport = @('Get-Otp','Get-OTPRemainingSeconds')
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 # CmdletsToExport = @()


### PR DESCRIPTION
Added `Get-OTPRemainingSeconds` function, which returns how many seconds are left in the current OTP refresh window. This is useful for scripts where we need to get the wait interval before requesting the next sequential OTP code. 
Use like
`$RetryDelayInSeconds = Get-OTPRemainingSeconds`
`Start-Sleep -Seconds $RetryDelayInSeconds`

PR also updates the manifest and README appropriately.